### PR TITLE
fixed missed lxml requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ CURDIR = os.path.abspath(os.path.dirname(__file__))
 REQUIRES = [
     'click',
     'beautifulsoup4',
+    'lxml',
     'colorama',
     'requests',
     'spinners',


### PR DESCRIPTION
App misses dependency lxml especially if installed through package manager with isolated environments (like pipx).

Sorry, without issue, despite recommendation in contributing.rst, problem is too trivial.